### PR TITLE
fix: keep module type until next major

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
   },
   "exclude": [
     "**/*.spec.js",
-    "lib",
     "jest.config.js",
+    "lib"
   ]
 }

--- a/tsconfig.settings.json
+++ b/tsconfig.settings.json
@@ -17,9 +17,11 @@
       "ES2017",
       "ES2018",
       "ES2019",
+      "ES2020",
+      "ES2021",
       "ScriptHost"
     ],
-    "module": "ES6",
+    "module": "CommonJS",
     "moduleResolution": "node",
     "newLine": "LF",
     "noImplicitAny": true,


### PR DESCRIPTION
`v1.5.2` was published with `esm` files, and it was `cjs` before