### PR TITLE
Allow manual constructors with optional injects

### DIFF
--- a/src/common/descriptor.ts
+++ b/src/common/descriptor.ts
@@ -47,7 +47,9 @@ class Descriptor {
         this.identifier = name;
       }
 
-      this.options = { ...rest };
+      if (Object.getOwnPropertyNames(rest).length > 0) {
+        this.options = { ...rest };
+      }
     }
 
     this.identifier = normalizeNameOrIdentifier(this.identifier);

--- a/src/decorators/configuration.ts
+++ b/src/decorators/configuration.ts
@@ -14,7 +14,7 @@ interface ConfigurationOptions {
   strict: boolean;
 }
 
-const knownConfigurationOptions = [
+const knownConfigurationOptions: Array<keyof ConfigurationOptions> = [
   'strict',
 ];
 

--- a/src/decorators/inject.ts
+++ b/src/decorators/inject.ts
@@ -20,11 +20,21 @@ interface InjectOptions {
    * The name of the injectable to inject.
    */
   name?: string;
+
+  /**
+   * Defines the inject as optional.
+   * If {@link true}, it will inject undefined when not being provided by a container.
+   * If {@link false}, it will throw an {@link Error} when not being provided by a container.
+   *
+   * @default false
+   */
+  optional?: boolean;
 }
 
-const knownInjectOptions = [
+const knownInjectOptions: Array<keyof InjectOptions> = [
   'eager',
   'name',
+  'optional',
 ];
 
 /**

--- a/src/decorators/injectable.ts
+++ b/src/decorators/injectable.ts
@@ -24,7 +24,7 @@ interface InjectableOptions {
   singleton?: boolean;
 }
 
-const knownInjectableOptions = [
+const knownInjectableOptions: Array<keyof InjectableOptions> = [
   'domain',
   'singleton',
 ];
@@ -108,7 +108,7 @@ function Injectable<Target extends ClassDecoratorTarget>(target: InjectableOptio
     }
 
     const bundle = odin.bundle(options.domain);
-    bundle.register(constructor, { ...options });
+    bundle.register(constructor);
 
     // @ts-ignore: if this initializer is added to the decorator signature, it allows for calling it, and we'd like to avoid it
     return constructor;

--- a/test/common/decorators.test.ts
+++ b/test/common/decorators.test.ts
@@ -35,7 +35,7 @@ describe('common', () => {
         applyEagers(Fixture, instance);
         expect(Secrets.getEagers(Fixture)).toStrictEqual([name]);
 
-        const spy = vi.fn(() => 0);
+        const spy = vi.fn(() => void 0);
         Object.defineProperty(instance, name, { get: spy });
 
         invokeEagers(Fixture, instance);
@@ -47,7 +47,7 @@ describe('common', () => {
       const name = 'initializer';
 
       test('should stash, apply and invoke', () => {
-        const spy = vi.fn(() => 0);
+        const spy = vi.fn(() => void 0);
 
         class Fixture {
           [name](): void {

--- a/test/decorators/initializer.test.ts
+++ b/test/decorators/initializer.test.ts
@@ -25,7 +25,7 @@ describe('decorators', () => {
     });
 
     test('should be called when instantiating the injectable', () => {
-      const initializerSpy = vi.fn(() => 0);
+      const initializerSpy = vi.fn(() => void 0);
 
       @Injectable
       class InitializerCalled {

--- a/test/decorators/injectable-constructor.test.ts
+++ b/test/decorators/injectable-constructor.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test, vi } from 'vitest';
+
+import { Inject } from '../../src/decorators/inject.js';
+import { Injectable } from '../../src/decorators/injectable.js';
+import { odin } from '../../src/singletons/odin.js';
+
+describe('decorators', () => {
+  describe('@Injectable', () => {
+    describe('constructor', () => {
+
+      @Injectable
+      class InjectableFixture {}
+
+      test('should support manual constructors if the injects are optional', () => {
+        const spy = vi.fn<[InjectableFixture]>(() => void 0);
+
+        @Injectable
+        class InjectableWithConstructorAndOptionalInject {
+          @Inject({ name: InjectableFixture.name, optional: true })
+          fixture: any;
+
+          constructor(fixture: InjectableFixture) {
+            this.fixture = fixture;
+            spy(fixture);
+          }
+        }
+
+        const container = odin.container();
+        const provided = container.provide<InjectableWithConstructorAndOptionalInject>(InjectableWithConstructorAndOptionalInject.name, true);
+
+        expect(spy).toHaveBeenCalledOnce();
+        expect(spy).toHaveBeenCalledWith(undefined);
+        expect(provided.fixture).toBeInstanceOf(InjectableFixture);
+
+        spy.mockReset();
+
+        const fixture = new InjectableFixture();
+        const manual = new InjectableWithConstructorAndOptionalInject(fixture);
+
+        expect(spy).toHaveBeenCalledOnce();
+        expect(spy).toHaveBeenCalledWith(fixture);
+        expect(manual.fixture).toBeInstanceOf(InjectableFixture);
+      });
+
+      test('should throw error when using manual constructor with required injects', () => {
+        const spy = vi.fn<[InjectableFixture]>(() => void 0);
+
+        @Injectable
+        class InjectableWithConstructorAndRequiredInject {
+          @Inject({ name: InjectableFixture.name })
+          fixture: any;
+
+          constructor(fixture: InjectableFixture) {
+            this.fixture = fixture;
+            spy(fixture);
+          }
+        }
+
+        const container = odin.container();
+        const provided = container.provide<InjectableWithConstructorAndRequiredInject>(InjectableWithConstructorAndRequiredInject.name, true);
+
+        expect(spy).toHaveBeenCalledOnce();
+        expect(spy).toHaveBeenCalledWith(undefined);
+        expect(provided.fixture).toBeInstanceOf(InjectableFixture);
+
+        spy.mockReset();
+
+        const fixture = new InjectableFixture();
+        const manual = new InjectableWithConstructorAndRequiredInject(fixture);
+
+        expect(spy).toHaveBeenCalledOnce();
+        expect(spy).toHaveBeenCalledWith(fixture);
+
+        expect(() => {
+          manual.fixture;
+        }).toThrow(`[odin]: There is no container at '${InjectableWithConstructorAndRequiredInject.name}'.`);
+      });
+
+    });
+  });
+});

--- a/test/stores/bundle-instantiate.test.ts
+++ b/test/stores/bundle-instantiate.test.ts
@@ -1,0 +1,43 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { DescriptorOptions } from '../../lib/common/descriptor.js';
+
+import { Bundle } from '../../src/stores/bundle.js';
+
+describe('bundle', () => {
+
+  const domain = 'domain';
+  const name = 'name';
+
+  const spy = vi.fn((..._: any[]) => void 0);
+
+  class Fixture {
+    constructor(...args: any[]) {
+      spy(...args);
+    }
+  }
+
+  beforeEach(() => {
+    spy.mockReset();
+  });
+
+  const matrix: [string, DescriptorOptions?, DescriptorOptions?][] = [
+    ['undefined to undefined', undefined, undefined],
+    ['defaulting to undefined', {}, undefined],
+    ['ignoring name', { name, something: 123 }, { something: 123 }],
+  ];
+
+  test.each(matrix)('should forward registered options to the injectable constructor: %s', (_, registerOptions, constructorOptions) => {
+    const bundle = new Bundle(domain);
+    bundle.register(Fixture, registerOptions);
+
+    const descriptor = bundle.get(Fixture.name);
+
+    if (descriptor) {
+      bundle.instantiate(descriptor);
+
+      expect(spy).toHaveBeenCalledOnce();
+      expect(spy).toHaveBeenCalledWith(constructorOptions);
+    }
+  });
+
+});

--- a/test/stores/bundle.test.ts
+++ b/test/stores/bundle.test.ts
@@ -5,7 +5,7 @@ import { Bundle } from '../../src/stores/bundle.js';
 describe('bundle', () => {
 
   test('should set domain', () => {
-    const domain = 'parent';
+    const domain = 'domain';
 
     const bundle = new Bundle(domain);
     expect(bundle).toBeInstanceOf(Bundle);


### PR DESCRIPTION
Allows implementing custom constructors for manual instantiation if all injects are optional.

### Test coverage
![image](https://github.com/philips-software/odin/assets/5903869/97832a6a-484f-4cd4-8a18-77bfc364380e)
